### PR TITLE
Automate build environment

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <!-- defaults -->
-  <default sync-j="4" revision="refs/tags/v01.00.05"/>
+  <default sync-j="4" revision="refs/tags/v01.00.04"/>
 
   <!-- remotes -->
   <remote fetch="http://git.yoctoproject.org/git/" name="yocto"/>
@@ -9,13 +9,14 @@
   <remote fetch="git://github.com/meta-qt5/" name="qt5"/>
   <remote fetch="git://github.com/intel-aero/" name="intel-aero"/>
   <remote fetch="git://github.com/IntelRealSense/" name="intel-realsense"/>
+  <remote fetch="git://github.com/cyphyworks/" name="cyphy"/>
 
   <!-- projects -->
   <project name="poky" remote="yocto" path="sources/poky" revision="e93596fe74927e2e2f4dd7f671994ccb9744cff8"/>
   <project name="meta-openembedded" remote="oe" path="sources/meta-openembedded" revision="851a064b53dca3b14dd33eaaaca9573b1a36bf0e"/>
   <project name="meta-qt4" remote="yocto" path="sources/meta-qt4" revision="fc9b050569e94b5176bed28b69ef28514e4e4553"/>
   <project name="meta-qt5" remote="qt5" path="sources/meta-qt5" revision="9aa870eecf6dc7a87678393bd55b97e21033ab48"/>
-  <project name="meta-intel-aero" remote="intel-aero" path="sources/meta-intel-aero">
+  <project name="meta-intel-aero" remote="cyphy" path="sources/meta-intel-aero" revision="af755a1f3b6677729cb32670b385b79e56939e8e">
       <copyfile dest="setup-environment" src="conf/base-script/setup-environment"/>
   </project>
   <project name="meta-intel-aero-connectivity" remote="intel-aero" path="sources/meta-intel-aero-connectivity"/>

--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- External projects -->
+  <!-- defaults -->
+  <default sync-j="4" revision="refs/tags/v01.00.04"/>
+
   <remote fetch="http://git.yoctoproject.org/git/" name="yocto"/>
   <remote fetch="git://git.openembedded.org/" name="oe"/>
   <remote fetch="git://github.com/meta-qt5/" name="qt5"/>

--- a/default.xml
+++ b/default.xml
@@ -30,11 +30,12 @@
 Build Instructions:
 ===================
 
-cd poky;
-
 # Initialize build environment variables by running
-export TEMPLATECONF=meta-intel-aero/conf/
-source oe-init-build-env
+source setup-environment <environment_name>
+# <environment_name> can be any name you want
+# You can have as many environements as you need
+# Run the same command to source an already preexisting environemnt
+
 
 # Build intel-aero-image
 bitbake intel-aero-image

--- a/default.xml
+++ b/default.xml
@@ -10,16 +10,19 @@
   <remote fetch="git://github.com/intel-aero/" name="intel-aero"/>
   <remote fetch="git://github.com/IntelRealSense/" name="intel-realsense"/>
 
-  <project name="poky" remote="yocto" revision="e93596fe74927e2e2f4dd7f671994ccb9744cff8"/>
-  <project name="meta-openembedded" remote="oe" path="poky/meta-openembedded" revision="851a064b53dca3b14dd33eaaaca9573b1a36bf0e"/>
-  <project name="meta-qt4" remote="yocto" path="poky/meta-qt4" revision="fc9b050569e94b5176bed28b69ef28514e4e4553"/>
-  <project name="meta-intel-aero" remote="intel-aero" path="poky/meta-intel-aero" revision="master"/>
-  <project name="meta-intel-aero-connectivity" remote="intel-aero" path="poky/meta-intel-aero-connectivity" revision="master"/>
-  <project name="meta-uav" remote="intel-aero" path="poky/meta-uav" revision="0f9395139b6a3c3f0f2c18a6a87f4048d0ca1a4f"/>
-  <project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="9aa870eecf6dc7a87678393bd55b97e21033ab48"/>
-  <project name="meta-ros" remote="intel-aero" path="poky/meta-ros" revision="0a28ea090c27494e443a5912daf060538bb9a004"/>
-  <project name="meta-intel-realsense" remote="intel-realsense" path="poky/meta-intel-realsense" revision="178fa9220d77f14d8b1623d259106815551a13f2"/>
-  <project name="intel-aero-samples" remote="intel-aero" path="poky/intel-aero-samples" revision="2c9f7f1f0f38d4fb25c03575dea70caf1d771cf3"/>
+  <!-- projects -->
+  <project name="poky" remote="yocto" path="sources/poky" revision="e93596fe74927e2e2f4dd7f671994ccb9744cff8"/>
+  <project name="meta-openembedded" remote="oe" path="sources/meta-openembedded" revision="851a064b53dca3b14dd33eaaaca9573b1a36bf0e"/>
+  <project name="meta-qt4" remote="yocto" path="sources/meta-qt4" revision="fc9b050569e94b5176bed28b69ef28514e4e4553"/>
+  <project name="meta-qt5" remote="qt5" path="sources/meta-qt5" revision="9aa870eecf6dc7a87678393bd55b97e21033ab48"/>
+  <project name="meta-intel-aero" remote="intel-aero" path="sources/meta-intel-aero">
+      <copyfile dest="setup-environment" src="conf/base-script/setup-environment"/>
+  </project>
+  <project name="meta-intel-aero-connectivity" remote="intel-aero" path="sources/meta-intel-aero-connectivity"/>
+  <project name="meta-uav" remote="intel-aero" path="sources/meta-uav"/>
+  <project name="meta-ros" remote="intel-aero" path="sources/meta-ros"/>
+  <project name="meta-intel-realsense" remote="intel-realsense" path="sources/meta-intel-realsense" revision="178fa9220d77f14d8b1623d259106815551a13f2"/>
+  <project name="intel-aero-samples" remote="intel-aero" path="sources/intel-aero-samples"/>
 </manifest>
 
 <!--

--- a/default.xml
+++ b/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <!-- defaults -->
-  <default sync-j="4" revision="refs/tags/v01.00.04"/>
+  <default sync-j="4" revision="refs/tags/v01.00.05"/>
 
   <!-- remotes -->
   <remote fetch="http://git.yoctoproject.org/git/" name="yocto"/>

--- a/default.xml
+++ b/default.xml
@@ -3,6 +3,7 @@
   <!-- defaults -->
   <default sync-j="4" revision="refs/tags/v01.00.04"/>
 
+  <!-- remotes -->
   <remote fetch="http://git.yoctoproject.org/git/" name="yocto"/>
   <remote fetch="git://git.openembedded.org/" name="oe"/>
   <remote fetch="git://github.com/meta-qt5/" name="qt5"/>


### PR DESCRIPTION
The modifications to the manifest file were inspired by that of the Freescale community BSP.

https://github.com/Freescale/fsl-community-bsp-platform

The script `setup-environment` ensures that both `local.conf` and `bblayers.conf` are set up correctly and it automatically updates to the latest version every time it runs. This ensures that a user can set up a build environment with less steps and with a lot less margin for error.
`setup-environment` lives on meta-intel-aero and it is meant to be used along side the following PR:
https://github.com/intel-aero/meta-intel-aero/pull/10

At the moment, there is an extra commit "Temp commit for testing" that should be removed before merging.
In order to test this PR, simply execute the following commands:
```
mkdir cyphy-aero
cd cyphy-aero
repo init -u https://github.com/cyphyworks/intel-aero-manifest.git
repo sync
source setup-environment integration-test1
bitbake *** anything you want ***
```
Make sure that the environmental variable TEMPLATECONF is not set. as it will cause the configuration to fail.
