### PR TITLE
rollback meta-openembedded to avoid breakage

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
 
   <project name="poky"       remote="yocto" revision="pyro"/>
   <project name="meta-virtualization" remote="yocto" revision="430233eb6e547aeaf6111c8159244bf1d82d09c1"/>
-  <project name="meta-openembedded" remote="oe" revision="pyro"/>
+  <project name="meta-openembedded" remote="oe" revision="b2ce52334cf88e07f703cf25ced92302edd5b0e9"/>
 
   <project name="meta-intel" remote="yocto" revision="pyro"/>
   <project name="meta-intel-aero-base" remote="intel-aero" revision="master"/>


### PR DESCRIPTION
The commit after this one on pyro branch broke the build of programs
linking to opencv. There is a fix in master but it has not been
backported yet.  Once it is, we can go back into tracking pyro.

Change-Id: I80d9ca7edb59b6e77f92752986dda7ee43fe06e4